### PR TITLE
Fix: query parameter type 변경

### DIFF
--- a/courses/tests.py
+++ b/courses/tests.py
@@ -201,7 +201,7 @@ class CourseListViewTest(TestCase):
 
     def test_list_by_category_success(self):
         client   = Client()
-        response = client.get('/courses?category=2')
+        response = client.get('/courses?category=category2')
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.json(), {
             'courses': [
@@ -211,7 +211,7 @@ class CourseListViewTest(TestCase):
                         'sub_category': 'sub_category1',
                         'user'        : 'user1',
                         'like'        : 1,
-                        'price'       : '1.00',
+                        'price'       : 1,
                         'thumbnail'   : 'null',
                         'month'       : 1,
                         'liked'       : False,
@@ -222,7 +222,7 @@ class CourseListViewTest(TestCase):
                         'sub_category': 'sub_category2',
                         'user'        : 'user1',
                         'like'        : 0,
-                        'price'       : '1.00',
+                        'price'       : 1,
                         'thumbnail'   : 'null',
                         'month'       : 1,
                         'liked'       : False,
@@ -232,7 +232,7 @@ class CourseListViewTest(TestCase):
 
     def test_list_by_category_invalid_value(self):
         client   = Client()
-        response = client.get('/courses?category=3')
+        response = client.get('/courses?category=category3')
         self.assertEqual(response.status_code, 404)
         self.assertEqual(response.json(), {
             'message' : 'INVALID_VALUE'
@@ -240,7 +240,7 @@ class CourseListViewTest(TestCase):
 
     def test_list_by_sub_category_success(self):
         client   = Client()
-        response = client.get('/courses?sub_category=2')
+        response = client.get('/courses?sub_category=sub_category2')
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.json(), {
             'courses': [
@@ -250,7 +250,7 @@ class CourseListViewTest(TestCase):
                         'sub_category': 'sub_category2',
                         'user'        : 'user1',
                         'like'        : 0,
-                        'price'       : '1.00',
+                        'price'       : 1,
                         'thumbnail'   : 'null',
                         'month'       : 1,
                         'liked'       : False,
@@ -260,7 +260,7 @@ class CourseListViewTest(TestCase):
 
     def test_list_by_sub_category_invalid_value(self):
         client   = Client()
-        response = client.get('/courses?sub_category=5')
+        response = client.get('/courses?sub_category=sub_category3')
         self.assertEqual(response.status_code, 404)
         self.assertEqual(response.json(), {
             'message' : 'INVALID_VALUE'
@@ -278,7 +278,7 @@ class CourseListViewTest(TestCase):
                         'sub_category': 'sub_category1',
                         'user'        : 'user1',
                         'like'        : 1,
-                        'price'       : '1.00',
+                        'price'       : 1,
                         'thumbnail'   : 'null',
                         'month'       : 1,
                         'liked'       : False,
@@ -289,7 +289,7 @@ class CourseListViewTest(TestCase):
                         'sub_category': 'sub_category2',
                         'user'        : 'user1',
                         'like'        : 0,
-                        'price'       : '1.00',
+                        'price'       : 1,
                         'thumbnail'   : 'null',
                         'month'       : 1,
                         'liked'       : False,
@@ -318,7 +318,7 @@ class CourseListViewTest(TestCase):
                         'sub_category': 'sub_category1',
                         'user'        : 'user1',
                         'like'        : 1,
-                        'price'       : '1.00',
+                        'price'       : 1,
                         'thumbnail'   : 'null',
                         'month'       : 1,
                         'liked'       : False,
@@ -329,7 +329,7 @@ class CourseListViewTest(TestCase):
                         'sub_category': 'sub_category2',
                         'user'        : 'user1',
                         'like'        : 0,
-                        'price'       : '1.00',
+                        'price'       : 1,
                         'thumbnail'   : 'null',
                         'month'       : 1,
                         'liked'       : False,

--- a/courses/views.py
+++ b/courses/views.py
@@ -55,16 +55,16 @@ class CourseDetailView(View):
 class CourseListView(View):
     def get(self, request):
         keyword         = request.GET.get('keyword', None)
-        category_id     = request.GET.get('category', None)
-        sub_category_id = request.GET.get('sub_category', None)
+        category_name     = request.GET.get('category', None)
+        sub_category_name = request.GET.get('sub_category', None)
         user            = get_user(request)
 
         # 카테고리 분류
-        if sub_category_id or category_id:
-            if SubCategory.objects.filter(id=sub_category_id).exists() or Category.objects.filter(id=category_id).exists():
+        if sub_category_name or category_name:
+            if SubCategory.objects.filter(name=sub_category_name).exists() or Category.objects.filter(name=category_name).exists():
                 course_list = Course.objects.select_related('sub_category','user').prefetch_related('liked_user').filter(
-                    Q(sub_category__id           = sub_category_id) |
-                    Q(sub_category__category__id = category_id))
+                    Q(sub_category__name           = sub_category_name) |
+                    Q(sub_category__category__name = category_name))
             else:
                 return JsonResponse({'message' : 'INVALID_VALUE'}, status=404)
         else:


### PR DESCRIPTION
>wecode PR message template 및 체크 리스트 입니다. 
아래 사항들을 전부 작성/체크 하시고 PR 해주세요!

## 수정 사항 간략한 한줄 요약
category endpoint에서 쿼리 파라미터값을 id --> name 으로 수정
		 
## 수정 사항들 자세한 내용

## 기타 질문 및 특이 사항
쿼리 파라미터를 id로 지정했을 때 프론트쪽에서 문제가 발생해서 수정했습니다.
프론트에서 카테고리 id 1,2 와 세부 카테고리 id 1,2가 중복이 돼서 name으로 바꾸면 중복되지 않을 것 같습니다.
이 때 name이 중복되는 경우도 있지만 카테고리와 세부 카테고리의 데이터가 그렇게 많지 않고 자주 수정되는 부분이 아니여서 괜찮다고 생각됩니다.

## 체크 리스트 (아래 사항들이 전부 체크되어야만 merge가 됩니다!)
- [x] 필요한 test들을 완료하였고 기능이 제대로 실행되는지 확인 하였습니다.
- [x] Wecode의 코드 스타일 가이드에 맞추어 코드를 작성 하였습니다.
- [x] 제가 의도한 파일들과 수정 사항들만 커밋이 된 것을 확인 하였습니다.
- [x] 본 수정 사항들을 팀원들과 사전에 상의하였고 팀원들 모두 해당 PR에 대하여 알고 있습니다.
- [x] Git rebase와 squash를 했고 커밋 수가 하나 인것을 확인 했습니다.
- [x] 유닛 테스트를 구현 하였고 모든 유닛 테스트가 통과 된것을 확인 하였습니다.
